### PR TITLE
Advanced keyinput & cursor manipulation [3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,29 @@ Command   | Description | Appearance
 ### `알아낸 거 목록`
 
 <details>
+  <summary><b>Debug logging without altering output to stdout</b></summary><br>
+
+  ```c
+  // 사용 중의 stdout 콘솔창 대신 대신 별도 외부 파일에 확인용 출력 출력
+  // 출력 형식에 변동이 가지 않아 값 확인용 디버깅 때에 편리하다.
+  FILE* fp = fopen("log.log", "a+");
+  fprintf(fp, "%d\n", lfcnt);
+  fclose(fp);
+
+  ```
+  
+  ###
+
+  ```c
+  // log.log에로의 실시간 변화 데이터는 아래와 같이 확인할 수 있다.
+  ```
+
+  ```sh
+  tail -f log.log
+  ```
+</details>
+
+<details>
   <summary><b>Cursor manipulation (go <i>up</i>) in linux</b></summary><br>
   <!-- syntax highlighting breaks on tabsize = 4, unfortunately -->
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Command   | Description | Appearance
 
   ```c
   // Answer 2: https://stackoverflow.com/a/26423857
+  // 주의: X에 0이 들어가도 최소 하나 출력된다.
+  // 이것 때문에 예상치 못한 곳에서 자주 당했다 .
 
   // In the linux terminal you may use terminal commands to move your cursor, such as
   printf("\033[8;5Hhello");   // Move to (8, 5) and output hello
@@ -379,6 +381,8 @@ Command   | Description | Appearance
   printf("\033[XC");  // Move right X columns;
   printf("\033[XD");  // Move left X columns;
   printf("\033[2J");  // Clear screen
+
+  // 화살표 키입력과 같이 위, 아래, 오른쪽, 왼쪽을 각각 A, B, C, D로 기억하면 편하다.
 
   ```
 </details>

--- a/mulcli.c
+++ b/mulcli.c
@@ -373,19 +373,22 @@ int main(int argc, char *argv[])
 
         //// 입력받은 버퍼에서 닉네임 조건 충족 여부를 먼저 확인한 후에 서버로 넘긴다.
 
-        else if (buf[0] == ' ') {
+        else if (buf[0] == ' ')
+        {
             moveCursorUp(warned ? 2 : 1, 0);
             printf("Name must not start with a SPACE character...\n");
             if (!warned) warned = 1;
         }
         
-        else if (namelen > NAME_SIZE) {
+        else if (namelen > NAME_SIZE)
+        {
             moveCursorUp(warned ? 2 : 1, 0);
             printf("Name must be shorter than %d characters!\n", NAME_SIZE);
             if (!warned) warned = 1;
         }
 
-        else {
+        else
+        {
             sprintf(message, "2000");
             sprintf(&message[CMDCODE_SIZE + 1], "%s", buf);
             
@@ -437,14 +440,17 @@ int main(int argc, char *argv[])
             // printf("No message.\r\n");
         }
         
-        else {
-            if (cmdcode == 1000 || cmdcode == 3000) {
+        else
+        {
+            if (cmdcode == 1000 || cmdcode == 3000)
+            {
                 // PRINT MSG AFTER REMOVING PREVIOUS LINES
                 if (!is_init) moveCursorUp(MIN_ERASE_LINES + PP_LINE_SPACE, 1);
                 else is_init = 0;
 
                 // CODE 1000: MESSAGE FROM SERVER
-                if (cmdcode == 1000) {
+                if (cmdcode == 1000)
+                {
                     // 이전 메시지도 서버 메시지일 경우 줄넘김 간격 하나 줄여줌
                     // 즉 클라이언트에서 서버로(그 반대도 포함) 전송자가 바뀐 경우에만 줄넘김 좀 더 넓혀 줌
                     if (cmdcode_prev == 1000) moveCursorUp(1, 0);
@@ -460,7 +466,8 @@ int main(int argc, char *argv[])
 
         // REPRINT PROMPT ONLY ON OUTPUT OCCURENCE
         // 수신 메시지 존재 or 입력 버퍼 비워짐으로 추가 출력이 존재하는 경우에만 '입력 문구' 출력.
-        if (!prompt_printed) {
+        if (!prompt_printed)
+        {
             for (int i = 0; i < PP_LINE_SPACE; i++) printf("\r\n");
             printf("%s", cmdmode ? cmd_message : pp_message);
             prompt_printed = 1;
@@ -487,6 +494,11 @@ int main(int argc, char *argv[])
              */
             switch (c)
             {
+                // note: TO-DOS
+                // mulfd에서의 키 입력 방식에 맞춰 switch(c) 내부 내용
+                // 갱신해 주어야 함
+                // <...>
+
                 // PRESSED CTRL + C
                 // 99 & 037
                 case 3:

--- a/mulfd.c
+++ b/mulfd.c
@@ -235,6 +235,36 @@ void print_behind_cursor(list_t* list, list_node_t* list_ptr, char firstchar, ch
     printf(" \033[%dD", restlen + lastcharcnt);
 }
 
+// CHECK LIST IS "LITERALLY" EMPTY
+/*
+ * 버퍼 리스트에 실제 데이터 값이 들어 있는지 확인
+ *
+ * 다음의 경우에 1 반환:
+ *   리스트가 비어 있음
+ *   리스트의 모든 노드의 val 값이 0, 공백, \r, \n 중 하나임
+ * 
+ * 리스트에 실제 의미 있는 값이 들어가 있으면 1 반환.
+ */
+int list_is_empty(list_t* list)
+{
+    if (list->head == list->tail) return 1;
+
+    list_node_t *node;
+    list_iterator_t *it = list_iterator_new(list, LIST_HEAD);
+
+    while (node = list_iterator_next(it))
+    {
+        if (node->val != 0 && node->val != ' ' && node->val != '\r' && node->val != '\n')
+        {
+            list_iterator_destroy(it);
+            return 0;
+        }
+    }
+
+    list_iterator_destroy(it);
+    return 1;
+}
+
 // LIST DATA TO BUFFER
 /* 
  * 인수들
@@ -779,8 +809,8 @@ int main(int argc, char **argv)
                 // PRESSED ENTER
                 case 13:
                 {
-                    // 내용 없이 엔터 때린 경우는 무시
-                    if (bp == blist->head && bp == blist->tail) break;
+                    // 버퍼 리스트에 유의미한 데이터가 없으면 무시
+                    if (list_is_empty(cmdmode ? clist : blist)) break;
 
                     if (cmdmode)
                     {

--- a/mulfd.c
+++ b/mulfd.c
@@ -130,17 +130,26 @@ void print_behind_cursor(list_t* list, list_node_t* list_ptr, char firstchar, ch
 {
     list_node_t *node = list_ptr;
     int restlen = 1;
+    int oneup = 0;
 
     if (firstchar) printf("%c", firstchar);
     while (node = node->next)
     {
-        if (node->val == '\r') break;
+        if (node->val == '\r')
+        {
+            if (list_ptr->next != node) break;
+            printf("\n");
+            oneup = 1;
+            // if (list_ptr->next == node) printf("\r\n"); continue;
+            // else break;
+        }
+        else restlen++;
         printf("%c", node->val);
-        restlen++;
         if (node == list->tail) break;
     }
     for (int i = 0; i < lastcharcnt; i++) printf("%c", lastchar);
     printf(" \033[%dD", restlen + lastcharcnt);
+    if (oneup) printf("\033[A");
 }
 
 // NOTE. this is for LINUX
@@ -456,9 +465,9 @@ list_node_t* list_insert(list_t* list, list_node_t* list_ptr, char newvalue)
 
 // https://stackoverflow.com/a/448982
 /*
- * "기존 터미널 모드" 저장 변수입니다
- * struct termios를 이용해 입력 방식을 바꿀 수 있다고 합니다!
- * 요걸로 엔터 없는, 타이핑 중에서의 직접 입력을 구현할 수 있습니다! 와!!
+ * "기존 터미널 모드" 저장 변수
+ * struct termios를 이용해 입력 방식을 바꿀 수 있다고 한다
+ * 이를 이용해 줄넘김 없이, 타이핑 중에서의 직접 입력을 구현할 수 있다    와
  */
 struct termios orig_termios;
 
@@ -1043,13 +1052,13 @@ int main(int argc, char **argv)
 
                     else
                     {
-                        printUntilEnd(blist, bp, " ", 1, LIST_HEAD);
-                        printf("\r\n");
-                        print_behind_cursor(blist, bp, 0, 0, 0);
+                        eraseInputSpace(blist, bp);
 
                         list_insert(blist, bp, '\n');
                         list_insert(blist, bp, '\r');
                         bp = bp->next->next;
+
+                        reprintList(blist, bp, 0);
                     }
 
                     break;

--- a/mulfd.c
+++ b/mulfd.c
@@ -410,17 +410,17 @@ list_node_t* transfer_list_data(char *buf, list_t *list, int emptylist)
     return list->head;
 }
 
-// FUCKING JESUS CHRIST
+// INSERT VALUE IN THE MIDDLE OF A BUFFER LIST
 /* 
  * 리스트 중간에 삽입한다
  * 
- * 문자 4글자 이하, 그 4글자들 사이에
- * [alt엔터]+[backspace] 3번 이상 치고 엔터 날렸을 때
- * Segmentation fault (core dumped)
- * 토요잔류 3시간 동안 못 고쳐서 머리 터졌음
- * 수학 진도 나가야 되는데 붙잡고 있다는 게
- * 어쨌든 고침
- * (list->len)++ 해 주는 게 답이었음
+ * 버그:
+ *   문자 4글자 이하, 그 4글자들 사이에
+ *   [ALT + ENTER] & [BACKSPACE] 3번 이상 치고 넘겼을 때
+ *   Segmentation fault (core dumped) 현상 발생
+ * 
+ * 해결
+ *   (list->len)++
  * 
  * list/list.c 내 디버깅 코드:
  * void list_destroy(list_t *self)에서
@@ -428,17 +428,17 @@ list_node_t* transfer_list_data(char *buf, list_t *list, int emptylist)
  * // for core dump debugging
  * // printf("[not yet, len: %d]\r\n", len);
  * 
- * 보니까 bllen, cllen 따로 만들지 않아도 list_t* 구조체에
- * len이라는 내장 변수 있어서 그냥 그거 쓰면 되었더라
- * 
- * list->len
+ + 보니까 bllen, cllen 따로 만들지 않아도 list_t* 구조체에
+ | len이라는 내장 변수 있어서 그냥 그거 쓰면 되었음
+ V 
+ : list->len
  * 
  * not incrementing it turned out to be the f reason of the f core dumping
  * incrementing it in [if (list_ptr == list->tail)] ALSO turns out to result in core dumping
  * 'cause list->len is already incremented IN list_rpush
  * .
  * .
- * 이런 된장할.
+ * [언짢으면서도 유익한 경험이었 다]
  */
 list_node_t* list_insert(list_t* list, list_node_t* list_ptr, char newvalue)
 {

--- a/mulfd.c
+++ b/mulfd.c
@@ -789,7 +789,7 @@ int main(int argc, char **argv)
 
                     else
                     {
-                        moveCursorUp(MIN_ERASE_LINES + PP_LINE_SPACE, 0);
+                        moveCursorUp(MIN_ERASE_LINES + PP_LINE_SPACE, 1);
                         cmdmode = 1;
                     }
 


### PR DESCRIPTION
# 글자 하나씩 입력받기 +

## 이전 단계 [Advanced keyinput & cursor manipulation [2] #6](https://github.com/nebobyeoli/tcpmulticli/pull/6)에서

## Completed Jobs

- [x] `공백`, `줄넘김`으로만 된 메시지는 `엔터` 날렸을 때 무시되도록
- [x] 출력물 출력 후에도, 화면에 표시된 사용자 입력물 유지

`[버그 해결]`
- [x] `줄넘김` 들어간 줄에 삽입할 때 `글자` 말고 `줄` 형식으로 `(같은 커서 위치에서 지속적으로)` 출력되도록
- [x] `세로로` 긴 <sup>엔터 많은</sup> 문자열 넘겼을 때도 최소 입력한 만큼은 커서 위로 올라가도록
- [x] 커서 뒤에 입력 데이터 존재하는 상황에서, 줄의 맨 끝에서 `ALT + ENTER` 넣었을 때 `줄넘김` 안 들어가는 현상
- [x] 줄넘김 앞, 줄의 끝에서 문자열 넣었을 때 `stdout`에 한 글자씩 출력되는 현상
- [x] `줄넘김` 앞에서 `오른쪽 화살표` 눌렀을 때 다음 줄로 커서 이동

## 다음 단계 [Advanced keyinput & cursor manipulation [4] #9](https://github.com/nebobyeoli/tcpmulticli/pull/9)으로 가시오

`Closed pull request.`
