### PR TITLE
1 : 1 채팅 기반 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,43 @@ Branch name | Pull request | Description
 **keyinput**  | [Keyboard input by character](https://github.com/nebobyeoli/tcpmulticli/pull/4) | `termios`를 이용한 사용자 정의 `kbhit()` 및 `getch()` 활성화 <br> 글자를 하나씩 입력받아 직접 할당하는 방식으로의 입력 구현 <br> 즉 `엔터` 없이도, 입력 `중의` 입력 버퍼를 직접 관리할 수 있도록 하는 작업
 **singles**  | [1 : 1 채팅 기반 구현](https://github.com/nebobyeoli/tcpmulticli/pull/11) | 개인 채팅 구현
 
+<!-- Message is concatenated via `sprintf()`.
+
+Example:
+```c
+// CREATE MESSAGE FOR write()
+// + 1 AND + 2 BELOW INDICATES LEAVING OUT [NULL] CHARACTERS
+// AS SEPARATORS TO DISTINGUISH FORMAT PARAMETERS ON read()
+
+/* sprintf()를 이용해,
+ * 한 개의 NULL 문자를 사이에 두고 char 배열에 작성하는 기법으로
+ * 각 메시지 데이터를 구분지어 저장한다.
+ */
+// APPEND CMDCODE
+sprintf(message, "%d", cmdcode);
+// APPEND NAME OF SENDER
+sprintf(&message[CMDCODE_SIZE + 1], "%s", sender);
+// APPEND MESSAGE
+sprintf(&message[CMDCODE_SIZE + NAME_SIZE + 2], "%s", msg);
+``` -->
+
+## Server log info
+
+```c
+// Output example
+```
+```txt
+Received from A [B] (C)
+
+<< HEARTBEAT at [t: %ld] from A [B] (C)
+```
+```c
+// t:   Time since server launch        [LONG INT] (time(0) 반환형)
+// A:   Client INDEX                    [INT]
+// B:   Client SOCKET                   [INT]
+// C:   Client NAME                     [CHAR*]
+```
+
 ## Cmd code significations
 
 #### 기본은 천의 자리 수와 백의 자리 수로 구분하는 것을 원칙으로 한다.
@@ -61,26 +98,6 @@ Name              | `cmdcode`      | `sender`    | `msg`
 ----------------- | -------------- | ----------- | ----------
 **Size constant** | `CMDCODE_SIZE` | `NAME_SIZE` | `BUF_SIZE`
 **Size**          | `4`            | `30`        | `1024 * n`
-
-<!-- Message is concatenated via `sprintf()`.
-
-Example:
-```c
-// CREATE MESSAGE FOR write()
-// + 1 AND + 2 BELOW INDICATES LEAVING OUT [NULL] CHARACTERS
-// AS SEPARATORS TO DISTINGUISH FORMAT PARAMETERS ON read()
-
-/* sprintf()를 이용해,
- * 한 개의 NULL 문자를 사이에 두고 char 배열에 작성하는 기법으로
- * 각 메시지 데이터를 구분지어 저장한다.
- */
-// APPEND CMDCODE
-sprintf(message, "%d", cmdcode);
-// APPEND NAME OF SENDER
-sprintf(&message[CMDCODE_SIZE + 1], "%s", sender);
-// APPEND MESSAGE
-sprintf(&message[CMDCODE_SIZE + NAME_SIZE + 2], "%s", msg);
-``` -->
 
 ## Nickname requisites
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,22 @@ Branch name | Pull request | Description
 **clistat** | [Manage Client Status](https://github.com/nebobyeoli/tcpmulticli/pull/2) | Server/Client 필요 기능 조건
 **emojis**  | [Emoji support](https://github.com/nebobyeoli/tcpmulticli/pull/1) | 텍스트 이미지 이모티콘 및 긴 `mms` 송수신에 관하여
 **keyinput**  | [Keyboard input by character](https://github.com/nebobyeoli/tcpmulticli/pull/4) | `termios`를 이용한 사용자 정의 `kbhit()` 및 `getch()` 활성화 <br> 글자를 하나씩 입력받아 직접 할당하는 방식으로의 입력 구현 <br> 즉 `엔터` 없이도, 입력 `중의` 입력 버퍼를 직접 관리할 수 있도록 하는 작업
+**singles**  | [1 : 1 채팅 기반 구현](https://github.com/nebobyeoli/tcpmulticli/pull/11) | 개인 채팅 구현
 
 ## Cmd code significations
 
-#### 1000의 배수, 적어도 100의 배수로 정하는 것을 원칙으로 한다.
+#### 기본은 천의 자리 수와 백의 자리 수로 구분하는 것을 원칙으로 한다.
 
-Cmd code | Meaning
--------- | ---------------------
-**1000** | Message from server
-**1500** | `HEARTBEAT` interaction<br>`HB 송수신 코드를 각각 따로 분리하지 않아도 될까?`
-**2000** | Set client nickname
-**3000** | Message communication
+Cmd code | Constant                | Meaning
+-------- | ----------------------- | ---------------------
+**1000** | `SERVMSG_CMD_CODE`      | **Message from server**
+**1500** | `HEARTBEAT_CMD_CODE`    | **HEARTBEAT 송수신**
+**1501** | `HEARTBEAT_REQ_CODE`    | **Memberlist request**
+  1601   | `SINGLECHAT_REQ_CODE`   | 개인 채팅 요청
+  1602   | `SINGLECHAT_RESP_CODE`  | 개인 채팅 요청 응답
+  2000   | `SETNAME_CMD_CODE`      | Set client nickname
+  3000   | `OPENCHAT_CMD_CODE`     | Messaging - Open chat `오픈채팅`
+**3001** | `SINGLECHAT_CMD_CODE`   | **Messaging - Single chat `개인채팅`**
 
 ## Message format
 
@@ -57,7 +62,7 @@ Name              | `cmdcode`      | `sender`    | `msg`
 **Size constant** | `CMDCODE_SIZE` | `NAME_SIZE` | `BUF_SIZE`
 **Size**          | `4`            | `30`        | `1024 * n`
 
-Message is concatenated via `sprintf()`.
+<!-- Message is concatenated via `sprintf()`.
 
 Example:
 ```c
@@ -75,7 +80,7 @@ sprintf(message, "%d", cmdcode);
 sprintf(&message[CMDCODE_SIZE + 1], "%s", sender);
 // APPEND MESSAGE
 sprintf(&message[CMDCODE_SIZE + NAME_SIZE + 2], "%s", msg);
-```
+``` -->
 
 ## Nickname requisites
 
@@ -260,6 +265,30 @@ Command   | Description | Appearance
   ```
   </details>
 
+</details>
+
+<details>
+  <summary>(stashed - 만들어 놓고 보니 사용 안 해서 다시 지움)</summary><br>
+
+  ```c
+  // mulfd.c
+
+  // singlechat <메시지>에 대한 항목 추출
+  // char *chat_msg:  추출된 메시지 저장 배열,
+  // char *message:   read() 받은 메시지 자체
+  void disassembleSinglechat(int *target_srl, char *chat_msg, char *message)
+  {
+      char tmp[5]={0,};
+      int offset = sizeof(int);
+  
+      memcpy(&tmp, &message[offset], sizeof(int));
+      offset += sizeof(int);
+      *target_srl = atoi(tmp);
+  
+      memcpy(chat_msg, &message[offset], MSG_SIZE);
+  }
+
+  ```
 </details>
 
 ##

--- a/mulcli.c
+++ b/mulcli.c
@@ -1124,11 +1124,10 @@ int main(int argc, char *argv[])
     // int bi = 0;     // buf string index
     // int ci = 0;     // cmd string index
 
+    int servmsg_printed = 0;
+
     while (1)
     {
-        // 이전 cmdcode값 저장
-        int cmdcode_prev = cmdcode;
-
         // RECEIVE MESSAGE
         // recv_msg()에서 read()를 실행하여 setsockopt으로 설정한 대기 시간만큼 기다린다.
         // 였는데 보편성 위해 그냥 read()로 바꿈
@@ -1169,15 +1168,28 @@ int main(int argc, char *argv[])
                 {
                     // 이전 메시지도 서버 메시지일 경우 줄넘김 간격 하나 줄여줌
                     // 즉 클라이언트에서 서버로(그 반대도 포함) 전송자가 바뀐 경우에만 줄넘김 좀 더 넓혀 줌
-                    if (cmdcode_prev == SERVMSG_CMD_CODE) moveCursorUp(1, 1, 0);
-                    printf("%s============ %s ============\r\n\r\n\r\n", cmdcode_prev == SERVMSG_CMD_CODE ? "" : "\r\n\r\n\r\n", &message[CMD_SIZE + NAME_SIZE]);
+                    if (servmsg_printed)
+                    {
+                        moveCursorUp(1, 1, 0);
+                    }
+                    else
+                    {
+                        printf("\r\n\n\n");
+                        servmsg_printed = 1;
+                    }
+                    printf("============ %s ============\r\n\n\n", &message[CMDCODE_SIZE + NAME_SIZE]);
                 }
 
                 // CODE 3001: 개인 채팅
-                else if (cmdcode == SINGLECHAT_CMD_CODE)
+                else
                 {
-                    printf("\r\n%d (names 받아서 대체 필요) sent: %s\r\n", client_data[MEMBER_SRL].target, &message[CMDCODE_SIZE * 3]);
-                    fflush(stdout);
+                    if (servmsg_printed) servmsg_printed = 0;
+
+                    if (cmdcode == SINGLECHAT_CMD_CODE)
+                    {
+                        printf("\r\n%d (names 받아서 대체 필요) sent: %s\r\n", client_data[MEMBER_SRL].target, &message[CMDCODE_SIZE * 3]);
+                        fflush(stdout);
+                    }
                 }
 
                 prompt_printed = 0;
@@ -1483,6 +1495,8 @@ int main(int argc, char *argv[])
 
                         moveCursorUp(MIN_ERASE_LINES + PP_LINE_SPACE + lfcnt, 1, bp);
                         if (is_init) { printf("\r\n"); is_init = 0; }
+
+                        if (servmsg_printed) servmsg_printed = 0;
 
                         // printf("\r\n%s sent: %s\r\n", sender, message); // original
                         printf("\r\n%d (names 받아서 대체 필요) sent: %s\r\n", MEMBER_SRL, &buf[CMDCODE_SIZE * 3]);

--- a/mulfd.c
+++ b/mulfd.c
@@ -908,7 +908,7 @@ int main(int argc, char **argv)
 
                 if (!has_client) has_client = 1;
                 write(client[i], "1500", CMDCODE_SIZE);
-                printf("\r\n>> HEARTBEAT at [t: %ld] to   [%d] (%s)", (now = time(0)) - inittime, client[i], names[i]);
+                printf("\r\n>> HEARTBEAT at [t: %ld] to   %d [%d] (%s)\r\n", (now = time(0)) - inittime, i, client[i], names[i]);
             }
 
             // 줄넘김 관리
@@ -1274,7 +1274,7 @@ int main(int argc, char **argv)
             {
                 if (client[i] < 0) {
                     client[i] = clnt_sock;
-                    printf("Client number: %d\r\n", i + 1);
+                    printf("Client index: %d\r\n", i);
                     printf("Client FD: %d\r\n", clnt_sock);
                     break;
                 }
@@ -1356,7 +1356,7 @@ int main(int argc, char **argv)
 
                     if (cmdcode == HEARTBEAT_CMD_CODE)
                     {
-                        printf("<< HEARTBEAT at [t: %ld] from [%d] (%s)\r\n", (now = time(0)) - inittime, client[i], names[i]);
+                        printf("\033[A<< HEARTBEAT at [t: %ld] from %d [%d] (%s)\r\n", (now = time(0)) - inittime, i, client[i], names[i]);
 
                         HeartBeatProcess(buf); // heartbeat 패킷 처리
                     }
@@ -1365,7 +1365,7 @@ int main(int argc, char **argv)
 
                     else if (cmdcode == HEARTBEAT_REQ_CODE)
                     {
-                        printf("<< MemberList Requested at [t: %ld] from [%d] (%s)\r\n", (now = time(0)) - inittime, client[i], names[i]);
+                        printf("<< MemberList Requested at [t: %ld] from %d [%d] (%s)\r\n", (now = time(0)) - inittime, i, client[i], names[i]);
 
                         char send_message[BUF_SIZE] = {0,};
                         clientListSerialize(send_message);
@@ -1384,15 +1384,13 @@ int main(int argc, char **argv)
                         if (client[req_to] == -1)
                         {
                             printf("%d is not an existing client.\r\n", req_to);
-                            write(client[i], "0", 2);
+                            send_singlechat_response(serv_sock, client[i], 0);
                         }
 
                         else
                         {
-                            write(client[i], "1", 2);
-
+                            send_singlechat_response(serv_sock, client[i], 1);
                             send_singlechat_request(i, client[req_to]);
-
                             printf("Requested chat to %d [%d].\r\n", req_to, client[req_to]);
                         }
                     }

--- a/mulfd.c
+++ b/mulfd.c
@@ -143,7 +143,7 @@ void sendAll(int clnt_cnt, int cmdcode, char *sender, char *msg, char *servlog)
         if (client[i] < 0 || names[i][0] == 0) continue;
 
         write(client[i], message, BUF_SIZE);
-        printf("Sent to client [%d] (%s)\r\n", client[i], names[i]);
+        printf("Sent to client %d [%d] (%s)\r\n", i, client[i], names[i]);
     }
 }
 
@@ -1319,7 +1319,7 @@ int main(int argc, char **argv)
                     if (cmdmode) moveCursorUp(MIN_ERASE_LINES, 1, 0);
                     else         moveCursorUp(MIN_ERASE_LINES + getLFcnt(blist), 1, bp);
 
-                    printf("Disconnected client [%d] (%s)\r\n", client[i], names[i]);
+                    printf("Disconnected client %d [%d] (%s)\r\n", i, client[i], names[i]);
                     printf("===================================\r\n");
                     fflush(0);
 
@@ -1359,7 +1359,7 @@ int main(int argc, char **argv)
                         if (cmdcode == OPENCHAT_CMD_CODE) msgoffset = CMDCODE_SIZE + NAME_SIZE;
                         else if (cmdcode == SINGLECHAT_CMD_CODE) msgoffset = CMDCODE_SIZE * 3;
                         
-                        printf("\r\nReceived from [%d] (%s): %s %s\r\n", client[i], names[i], buf, &buf[msgoffset]);
+                        printf("\r\nReceived from %d [%d] (%s): %s %s\r\n", i, client[i], names[i], buf, &buf[msgoffset]);
                     }
 
                     //
@@ -1459,7 +1459,7 @@ int main(int argc, char **argv)
                             memset(names[i], 0, NAME_SIZE);
                             memset(client_data[i].nick, 0, NAME_SIZE);
                             sprintf(names[i], "%s", &buf[CMDCODE_SIZE + 1]);
-                            printf("Set name of client [%d] as [%s]\r\n", client[i], names[i]);
+                            printf("Set name of client %d [%d] as [%s]\r\n", i, client[i], names[i]);
 
                             // SEND JOIN INFORMATION TO ALL CLIENTS
                             memset(message, 0, BUF_SIZE);
@@ -1519,7 +1519,7 @@ int main(int argc, char **argv)
 
                     else
                     {
-                        printf("Error reading cmdcode from [%d]!\r\n", client[i]);
+                        printf("Error reading cmdcode from %d [%d]!\r\n", i, client[i]);
                     }
                 }
 


### PR DESCRIPTION
# 일단 <sup>푸시로</sup> 날린 거

## Completed Jobs

- [x] 1 : 1 요청 후 수락/거절
  작동 순서:
  1. 클라이언트가 서버에 접속함
  2. `target 클라 번호` 입력
  3. `target` 클라가 배열에 존재하는지 서버가 답해줌
  4. 있으면 `target` 클라에게 1:1 `accept` 할 껀지 물어봄
  5. `yes`면 `cmdmode 아웃`, `no`면 그냥 기대로 [`cmdmode` 지속]

`버그 해결`
- [x] 수시로 오는 `heartbeat`에 의해, 클라이언트 쪽에서 메시지 먹힘 현상 발생했던 거
- [x] `singlechat message`: 서버가 송신자도 수신자도 같은 클라(송신자)로 날리고 있었음`(...)`
- [x] 닉네임 아직 설정 안 된 클라에 대하서는 `1:1 요청` 왔을 때 `없는 클라이언트`처럼 취급.
  `%d is not an existing client.`
- [x] `MESSAGE FROM SERVER` 다시 인식하도록 (수신은 하는데 제대로 출력 안 됨)
  `문제 원인` : 클라 쪽에서 메시지를 `&message[CMDCODE_SIZE + NAME_SIZE]`로 인식해야 하는데
  `CMDCODE_SIZE`를 써야 할 것을 `CMD_SIZE`라고 잘못 넣었었음 📄 

## Other

- `cmdcode_prev` 없애고 `servmsg_printed`로 대체함: `HEARTBEAT` 등으로 인한 `"중간 cmdcode값"`이 발생하기 때문
- 클라 나갔을 때, 서버에서 클라의 `target` 설정 해제해 주는 등의 이후 작업은 아직 안 만들었음

##

`이거 하고 일단 main 머지할거임`
